### PR TITLE
Feature/add builder mcp support

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -6,14 +6,15 @@ This repository hosts a React app that is always embedded in an iframe inside th
 - All data access must go through `Flowgear.Sdk.invoke` from the `flowgear-webapp` package. The Console holds the auth cookie and performs the HTTP call on behalf of the iframe. Never call APIs directly with `fetch`/`axios`.
 - Use the API descriptors in the root `openapi.yml` to discover available endpoints, but pass only the HTTP method and relative path to `Flowgear.Sdk.invoke(...)`. Always send HTTP methods in uppercase (e.g., `GET`, `POST`, `PUT`, `PATCH`) even if `openapi.yml` lists them in lowercase. Ignore the `servers`, `components`, and `security` sections in that file.
 - Place feature-specific work under `components`, `models`, `services`, and `utils`, splitting by functional area.
-- This repo should only ever contain client side code. Whenever there's a need to connect to a data source, this should be done via a Flowgear workflow invoke, see below
+- This repo should only ever contain client side code. When a required API is not available, you should build or edit a Flowgear workflow - see below.
 
 # Flowgear workflows
 
 - Workflows describe steps to acquire, push or otherwise integrate between data sources
-- There should be a registered MCP server called 'flowgear'.
-- Read its resources to access prompt information that explains how to use the available tools to 
-  build a Flowgear workflow for a specific objective.
+- There should be a registered MCP server called `flowgear` which contains all the tools you need to find, design and save workflows. Ask the user which server to use if there isn't one called `flowgear`.
+- There is an MCP resource that explains how to use the tools. Read that before doing anything else.
+- For a workflow to be invoked via this app, it must be HTTP-triggered. First step in the Workflow should be v2.Http Node, HttpReceive method (where method and uri binding are declared as parameers), last step should be v2.Http Node, HttpRespond method
+- After creating or editing a workflow, download a fresh openapi.yml definition so that you can see verify the service definitions in order to bind front-end.
 
 
 ## Flowgear SDK helpers

--- a/agents.md
+++ b/agents.md
@@ -6,6 +6,15 @@ This repository hosts a React app that is always embedded in an iframe inside th
 - All data access must go through `Flowgear.Sdk.invoke` from the `flowgear-webapp` package. The Console holds the auth cookie and performs the HTTP call on behalf of the iframe. Never call APIs directly with `fetch`/`axios`.
 - Use the API descriptors in the root `openapi.yml` to discover available endpoints, but pass only the HTTP method and relative path to `Flowgear.Sdk.invoke(...)`. Always send HTTP methods in uppercase (e.g., `GET`, `POST`, `PUT`, `PATCH`) even if `openapi.yml` lists them in lowercase. Ignore the `servers`, `components`, and `security` sections in that file.
 - Place feature-specific work under `components`, `models`, `services`, and `utils`, splitting by functional area.
+- This repo should only ever contain client side code. Whenever there's a need to connect to a data source, this should be done via a Flowgear workflow invoke, see below
+
+# Flowgear workflows
+
+- Workflows describe steps to acquire, push or otherwise integrate between data sources
+- There should be a registered MCP server called 'flowgear'.
+- Read its resources to access prompt information that explains how to use the available tools to 
+  build a Flowgear workflow for a specific objective.
+
 
 ## Flowgear SDK helpers
 - `init()` is called in `src/index.tsx` to register the app with the host console before rendering.

--- a/agents.md
+++ b/agents.md
@@ -8,7 +8,7 @@ This repository hosts a React app that is always embedded in an iframe inside th
 - Place feature-specific work under `components`, `models`, `services`, and `utils`, splitting by functional area.
 - This repo should only ever contain client side code. When a required API is not available, you should build or edit a Flowgear workflow - see below.
 
-# Flowgear workflows
+## Flowgear workflows
 
 - Workflows describe steps to acquire, push or otherwise integrate between data sources
 - There should be a registered MCP server called `flowgear` which contains all the tools you need to find, design and save workflows. Ask the user which server to use if there isn't one called `flowgear`.
@@ -16,6 +16,8 @@ This repository hosts a React app that is always embedded in an iframe inside th
 - For a workflow to be invoked via this app, it must be HTTP-triggered. First step in the Workflow should be v2.Http Node, HttpReceiveJsonObject or HttpReceiveJsonArray method (where method and uri binding are declared as parameters), last step should be v2.Http Node, HttpRespondJsonObject or HttpRespondJsonArray method
 - After creating or editing a workflow, download a fresh openapi.yml definition so that you can see the service definitions in order to bind front-end.
 
+## General
+- Don't use forms, the web app runs in a sandbox and form submissions are not allowed.
 
 ## Flowgear SDK helpers
 - `init()` is called in `src/index.tsx` to register the app with the host console before rendering.

--- a/agents.md
+++ b/agents.md
@@ -13,8 +13,8 @@ This repository hosts a React app that is always embedded in an iframe inside th
 - Workflows describe steps to acquire, push or otherwise integrate between data sources
 - There should be a registered MCP server called `flowgear` which contains all the tools you need to find, design and save workflows. Ask the user which server to use if there isn't one called `flowgear`.
 - There is an MCP resource that explains how to use the tools. Read that before doing anything else.
-- For a workflow to be invoked via this app, it must be HTTP-triggered. First step in the Workflow should be v2.Http Node, HttpReceive method (where method and uri binding are declared as parameers), last step should be v2.Http Node, HttpRespond method
-- After creating or editing a workflow, download a fresh openapi.yml definition so that you can see verify the service definitions in order to bind front-end.
+- For a workflow to be invoked via this app, it must be HTTP-triggered. First step in the Workflow should be v2.Http Node, HttpReceiveJsonObject or HttpReceiveJsonArray method (where method and uri binding are declared as parameters), last step should be v2.Http Node, HttpRespondJsonObject or HttpRespondJsonArray method
+- After creating or editing a workflow, download a fresh openapi.yml definition so that you can see the service definitions in order to bind front-end.
 
 
 ## Flowgear SDK helpers


### PR DESCRIPTION
Modifies prompt to expect an MCP builder server that the agent can use to generate workflows as backend. Pairs with https://github.com/Flowgear/flowgear22-core/pull/2284